### PR TITLE
Switchboard.vala: Remove unnecessary expands

### DIFF
--- a/src/Switchboard.vala
+++ b/src/Switchboard.vala
@@ -279,16 +279,13 @@ namespace Switchboard {
             category_view.load_default_plugs.begin ();
 
             category_scrolled = new Gtk.ScrolledWindow (null, null);
-            category_scrolled.vexpand = true;
             category_scrolled.add_with_viewport (category_view);
 
             alert_view = new Granite.Widgets.AlertView ("", "", "");
             alert_view.no_show_all = true;
-            alert_view.vexpand = true;
             alert_view.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
             stack = new Gtk.Stack ();
-            stack.expand = true;
             stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
             stack.add_named (alert_view, "alert");
             stack.add_named (category_scrolled, "main");


### PR DESCRIPTION
It doesn't appear to be necessary  to expand these widgets