### PR TITLE
fix calling hidden()

### DIFF
--- a/src/Switchboard.vala
+++ b/src/Switchboard.vala
@@ -454,6 +454,7 @@ namespace Switchboard {
                 navigation_button.hide ();
             } else {
                 if (previous_plugs.size > 0 && stack.get_visible_child_name () != "main") {
+                    print("SWITCHBOARD navigate\n");
                     if (current_plug != null) {
                         current_plug.hidden();
                     }
@@ -474,6 +475,10 @@ namespace Switchboard {
                 }
 
                 if (supported_settings.has_key (setting_path)) {
+                    print("SWITCHBOARD link\n");
+                    if (current_plug != null) {
+                        current_plug.hidden();
+                    }
                     load_plug (plug);
                     open_window = supported_settings.get (setting_path);
                     return true;

--- a/src/Switchboard.vala
+++ b/src/Switchboard.vala
@@ -454,7 +454,6 @@ namespace Switchboard {
                 navigation_button.hide ();
             } else {
                 if (previous_plugs.size > 0 && stack.get_visible_child_name () != "main") {
-                    print("SWITCHBOARD navigate\n");
                     if (current_plug != null) {
                         current_plug.hidden();
                     }
@@ -475,7 +474,6 @@ namespace Switchboard {
                 }
 
                 if (supported_settings.has_key (setting_path)) {
-                    print("SWITCHBOARD link\n");
                     if (current_plug != null) {
                         current_plug.hidden();
                     }

--- a/src/Switchboard.vala
+++ b/src/Switchboard.vala
@@ -455,8 +455,9 @@ namespace Switchboard {
             } else {
                 if (previous_plugs.size > 0 && stack.get_visible_child_name () != "main") {
                     if (current_plug != null) {
-                        current_plug.hidden();
+                        current_plug.hidden ();
                     }
+                    
                     load_plug (previous_plugs.@get (0));
                     previous_plugs.remove_at (0);
                 } else {
@@ -475,8 +476,9 @@ namespace Switchboard {
 
                 if (supported_settings.has_key (setting_path)) {
                     if (current_plug != null) {
-                        current_plug.hidden();
+                        current_plug.hidden ();
                     }
+                    
                     load_plug (plug);
                     open_window = supported_settings.get (setting_path);
                     return true;

--- a/src/Switchboard.vala
+++ b/src/Switchboard.vala
@@ -454,6 +454,9 @@ namespace Switchboard {
                 navigation_button.hide ();
             } else {
                 if (previous_plugs.size > 0 && stack.get_visible_child_name () != "main") {
+                    if (current_plug != null) {
+                        current_plug.hidden();
+                    }
                     load_plug (previous_plugs.@get (0));
                     previous_plugs.remove_at (0);
                 } else {


### PR DESCRIPTION
plug's hidden() method was not called when navigating back to another plug and when opening other with link  

i tested this with display plug ([related issue](https://github.com/elementary/switchboard-plug-display/issues/55)):
- got to Universal Access > Display > Display settings... now navigate back to Universal Access - display label on top left should not be shown
- open Displays than open some other settings with url, like settings://time - display label should hide

