### PR TITLE
Change default window size

### DIFF
--- a/schemas/org.pantheon.switchboard.gschema.xml
+++ b/schemas/org.pantheon.switchboard.gschema.xml
@@ -11,12 +11,12 @@
 			<description>The saved state of the window.</description>
 		</key>
 		<key name="window-width" type="i">
-			<default>950</default>
+			<default>850</default>
 			<summary>The saved width of the window.</summary>
 			<description>The saved width of the window. Must be greater than 700, or it will not take effect.</description>
 		</key>
 		<key name="window-height" type="i">
-			<default>670</default>
+			<default>520</default>
 			<summary>The saved height of the window.</summary>
 			<description>The saved height of the window. Must be greater than 400, or it will not take effect.</description>
 		</key>


### PR DESCRIPTION
I'm guessing this is a result of window sizes being calculated differently in a new mutter.

OLD:

![screenshot from 2018-01-02 17 48 47](https://user-images.githubusercontent.com/7277719/34506845-387660be-efe5-11e7-8c46-cd3387f7bc24.png)


NEW:

![screenshot from 2018-01-02 17 48 21](https://user-images.githubusercontent.com/7277719/34506854-3d8b8c3c-efe5-11e7-81aa-61b4b5370015.png)


