### PR TITLE
Valign category separators

### DIFF
--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -28,7 +28,8 @@ namespace Switchboard {
             var category_label = new Granite.HeaderLabel (Switchboard.CategoryView.get_category_name (category));
 
             var h_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
-            h_separator.set_hexpand (true);
+            h_separator.hexpand = true;
+            h_separator.valign = Gtk.Align.CENTER;
 
             flowbox = new Gtk.FlowBox ();
             flowbox.activate_on_single_click = true;


### PR DESCRIPTION
Fixes a bug that makes separators big and dumb

I tried to work around this in CSS, but it breaks other stuff. It looks like this is also broken in Adwaita, so it seems like Gtk+ doesn't expect separators to be filled in the wrong direction

(Gtk.Align.FILL is a bad default)