### PR TITLE
RDNN binary name

### DIFF
--- a/data/io.elementary.switchboard.desktop.in
+++ b/data/io.elementary.switchboard.desktop.in
@@ -2,7 +2,7 @@
 Type=Application
 Name=System Settings
 Comment=Change system and user settings
-Exec=switchboard %u
+Exec=io.elementary.switchboard %u
 Icon=preferences-desktop
 Terminal=false
 StartupNotify=true

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project(
-    'switchboard',
+    'io.elementary.switchboard',
     'c', 'vala',
     version: '2.3.1',
 )
@@ -13,7 +13,7 @@ add_project_arguments([
     language: 'c'
 )
 
-plugs_dir = join_paths(get_option('prefix'), get_option('libdir'), meson.project_name())
+plugs_dir = join_paths(get_option('prefix'), get_option('libdir'), 'switchboard')
 
 i18n = import('i18n')
 pkg = import('pkgconfig')


### PR DESCRIPTION
Fixes #6 

Changes the name of the binary (looks like everything else is already updated). Does not change the library name or plugs directory name