### PR TITLE
AppData: Add compulsory for Pantheon

### DIFF
--- a/data/io.elementary.switchboard.appdata.xml.in
+++ b/data/io.elementary.switchboard.appdata.xml.in
@@ -20,6 +20,7 @@
       <image>https://raw.githubusercontent.com/elementary/switchboard/master/data/screenshot.png</image>
     </screenshot>
   </screenshots>
+  <compulsory_for_desktop>Pantheon</compulsory_for_desktop>
   <developer_name>elementary LLC.</developer_name>
   <url type="homepage">https://elementary.io/</url>
   <url type="bugtracker">https://github.com/elementary/switchboard/issues</url>


### PR DESCRIPTION
As indicated in the [spec](https://www.freedesktop.org/software/appstream/docs/chap-CollectionData.html), this should prevent people from breaking their DE