### PR TITLE
CategoryFlowbox: vexpand everything

### DIFF
--- a/data/io.elementary.switchboard.appdata.xml.in
+++ b/data/io.elementary.switchboard.appdata.xml.in
@@ -16,6 +16,7 @@
         <ul>
           <li>Fix an issue that prevented tiling on small displays</li>
           <li>Fix an issue with restoring the correct window size</li>
+          <li>Make the category grid fill the available space when maximized</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -30,6 +30,7 @@ namespace Switchboard {
 
         construct {
             var category_label = new Granite.HeaderLabel (Switchboard.CategoryView.get_category_name (category));
+            category_label.vexpand = true;
 
             var h_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
             h_separator.hexpand = true;
@@ -43,6 +44,7 @@ namespace Switchboard {
             flowbox.min_children_per_line = 5;
             flowbox.max_children_per_line = 5;
             flowbox.selection_mode = Gtk.SelectionMode.NONE;
+            flowbox.vexpand = true;
 
             margin_bottom = 12;
             margin_start = 12;
@@ -50,6 +52,8 @@ namespace Switchboard {
 
             column_spacing = 3;
             row_spacing = 6;
+
+            vexpand = true;
 
             attach (category_label, 0, 0, 1, 1);
             attach (h_separator, 1, 0, 1, 1);


### PR DESCRIPTION
Makes the grid fill the space so its not cramped at the top of the display when maximized

## BEFORE
Maximized on a small display
![Screenshot from 2020-01-14 09 35 58@2x](https://user-images.githubusercontent.com/7277719/72367613-574d0c80-36b1-11ea-8374-9bbd53351659.png)

## AFTER
Tiled on a big display
![Screenshot from 2020-01-14 09 34 35](https://user-images.githubusercontent.com/7277719/72367605-561bdf80-36b1-11ea-9948-6339f7618999.png)

Maximized on a big display
![Screenshot from 2020-01-14 09 34 43](https://user-images.githubusercontent.com/7277719/72367608-561bdf80-36b1-11ea-9337-85a29708ef84.png)

Maximized on a small display
![Screenshot from 2020-01-14 09 35 09@2x](https://user-images.githubusercontent.com/7277719/72367611-56b47600-36b1-11ea-8cb0-56edf1b13217.png)

