### PR TITLE
Application: minor search cleanups

### DIFF
--- a/data/io.elementary.switchboard.appdata.xml.in
+++ b/data/io.elementary.switchboard.appdata.xml.in
@@ -15,6 +15,7 @@
       <description>
         <ul>
           <li>Redesign search results view</li>
+          <li>Tab key moves focus out of search</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -49,13 +49,6 @@ namespace Switchboard {
         private static string? link = null;
         private static bool opened_directly = false;
         private static bool should_animate_next_transition = true;
-        private const uint[] NAVIGATION_KEYS = {
-            Gdk.Key.Up,
-            Gdk.Key.Down,
-            Gdk.Key.Left,
-            Gdk.Key.Right,
-            Gdk.Key.Return
-        };
 
         construct {
             application_id = "io.elementary.switchboard";
@@ -283,15 +276,18 @@ namespace Switchboard {
                 switch (event.keyval) {
                     case Gdk.Key.Return:
                         searchview.activate_first_item ();
-                        return true;
+                        return Gdk.EVENT_STOP;
+                    case Gdk.Key.Down:
+                        search_box.move_focus (Gtk.DirectionType.TAB_FORWARD);
+                        return Gdk.EVENT_STOP;
                     case Gdk.Key.Escape:
                         search_box.text = "";
-                        return true;
+                        return Gdk.EVENT_STOP;
                     default:
                         break;
                 }
 
-                return false;
+                return Gdk.EVENT_PROPAGATE;
             });
 
             back_action.activate.connect (() => {
@@ -341,19 +337,21 @@ namespace Switchboard {
             });
 
             main_window.key_press_event.connect ((event) => {
-                // Down key from search_bar should move focus to CategoryVIew
-                if (search_box.has_focus && event.keyval == Gdk.Key.Down) {
-                    search_box.move_focus (Gtk.DirectionType.TAB_FORWARD);
-                    return Gdk.EVENT_STOP;
+                switch (event.keyval) {
+                    // arrow or tab key is being used by CategoryView to navigate
+                    case Gdk.Key.Up:
+                    case Gdk.Key.Down:
+                    case Gdk.Key.Left:
+                    case Gdk.Key.Right:
+                    case Gdk.Key.Return:
+                    case Gdk.Key.Tab:
+                        return Gdk.EVENT_PROPAGATE;
                 }
 
-                // arrow key is being used by CategoryView to navigate
-                if (event.keyval in NAVIGATION_KEYS)
-                    return Gdk.EVENT_PROPAGATE;
-
                 // Don't focus if it is a modifier or if search_box is already focused
-                if ((event.is_modifier == 0) && !search_box.has_focus)
+                if ((event.is_modifier == 0) && !search_box.has_focus) {
                     search_box.grab_focus ();
+                }
 
                 return Gdk.EVENT_PROPAGATE;
             });


### PR DESCRIPTION
* Move navkeys to a case statement since this is only used in one context
* Return `Gdk.EVENT_FOO` instead of true/false for clarity
* Connect to down key in the searchbox instead of the window so we don't have to check if the searchbox has focus
* Don't swallow tab key