### PR TITLE
SearchView: Fix "assertion 'GTK_IS_ENTRY (entry)' failed" error

### DIFF
--- a/src/SearchView.vala
+++ b/src/SearchView.vala
@@ -18,7 +18,7 @@
 */
 
 public class Switchboard.SearchView : Gtk.ScrolledWindow {
-    private Gtk.SearchEntry search_entry;
+    private Gtk.SearchEntry search_entry = SwitchboardApp.instance.search_box;
     private Gtk.ListBox listbox;
 
     construct {
@@ -39,7 +39,6 @@ public class Switchboard.SearchView : Gtk.ScrolledWindow {
 
         load_plugs.begin ();
 
-        search_entry = SwitchboardApp.instance.search_box;
         search_entry.search_changed.connect (() => {
             alert_view.title = _("No Results for “%s”").printf (search_entry.text);
             listbox.invalidate_filter ();

--- a/src/SearchView.vala
+++ b/src/SearchView.vala
@@ -18,7 +18,7 @@
 */
 
 public class Switchboard.SearchView : Gtk.ScrolledWindow {
-    private Gtk.SearchEntry search_entry = SwitchboardApp.instance.search_box;
+    private Gtk.SearchEntry search_entry;
     private Gtk.ListBox listbox;
 
     construct {
@@ -29,6 +29,8 @@ public class Switchboard.SearchView : Gtk.ScrolledWindow {
         );
         alert_view.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
         alert_view.show_all ();
+
+        search_entry = SwitchboardApp.instance.search_box;
 
         listbox = new Gtk.ListBox ();
         listbox.selection_mode = Gtk.SelectionMode.BROWSE;


### PR DESCRIPTION
We now get the following error message on launching Switchboard:

```
(io.elementary.switchboard:31100): Gtk-CRITICAL **: 18:15:42.406: gtk_entry_get_text: assertion 'GTK_IS_ENTRY (entry)' failed
```

This is because `search_entry` is not initialized when [`SearchView.filter_func ()` is called](https://github.com/elementary/switchboard/blob/master/src/SearchView.vala#L35).
