### PR TITLE
PlugsManager: Use GLib.ModuleFlags.LAZY instead of deprecated BIND_LAZY

### DIFF
--- a/lib/PlugsManager.vala
+++ b/lib/PlugsManager.vala
@@ -45,7 +45,7 @@ public class Switchboard.PlugsManager : GLib.Object {
             error ("Switchboard is not supported by this system!");
         }
 
-        Module module = Module.open (path, ModuleFlags.BIND_LAZY);
+        Module module = Module.open (path, ModuleFlags.LAZY);
         if (module == null) {
             critical (Module.error ());
             return;


### PR DESCRIPTION
Use `GLib.ModuleFlags.LAZY` instead of `GLib.ModuleFlags.BIND_LAZY` which has been [deprecated since vala-0.46](https://valadoc.org/gmodule-2.0/GLib.ModuleFlags.BIND_LAZY.html)
