### PR TITLE
Application: Remove old GCC compat layer

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -82,17 +82,8 @@ namespace Switchboard {
                 if (link.has_suffix ("/")) {
                     link = link.substring (0, link.last_index_of_char ('/'));
                 }
-
             } else {
-                warning ("Calling Switchboard directly is deprecated, please use the settings:// scheme instead");
-                var name = file.get_basename ();
-                if (":" in name) {
-                    var parts = name.split (":");
-                    plug_to_open = gcc_to_switchboard_code_name (parts[0]);
-                    open_window = parts[1];
-                } else {
-                    plug_to_open = gcc_to_switchboard_code_name (name);
-                }
+                critical ("Calling Switchboard directly is unsupported, please use the settings:// scheme instead");
             }
 
             activate ();
@@ -470,36 +461,6 @@ namespace Switchboard {
             }
 
             return true;
-        }
-
-        private string? gcc_to_switchboard_code_name (string gcc_name) {
-            // list of names taken from GCC's shell/cc-panel-loader.c
-            switch (gcc_name) {
-                case "background": return "pantheon-desktop";
-                case "bluetooth": return "network-pantheon-bluetooth";
-                case "color": return "hardware-gcc-color";
-                case "datetime": return "system-pantheon-datetime";
-                case "display": return "system-pantheon-display";
-                case "info": return "system-pantheon-about";
-                case "keyboard": return "hardware-pantheon-keyboard";
-                case "network": return "pantheon-network";
-                case "power": return "system-pantheon-power";
-                case "printers": return "pantheon-printers";
-                case "privacy": return "pantheon-security-privacy";
-                case "region": return "system-pantheon-locale";
-                case "sharing": return "pantheon-sharing";
-                case "sound": return "hardware-gcc-sound";
-                case "universal-access": return "pantheon-accessibility";
-                case "user-accounts": return "system-pantheon-useraccounts";
-                case "wacom": return "hardware-gcc-wacom";
-                case "notifications": return "personal-pantheon-notifications";
-
-                // not available on our system
-                case "search":
-                    return null;
-            }
-
-            return null;
         }
     }
 }


### PR DESCRIPTION
I'm pretty sure all of these are out of date and don't work. Regardless, this doesn't really cause any "breakage", Switchboard will just open to the category view