### PR TITLE
Application: Set title, search box, navbutton on visible-child.notify

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -136,7 +136,7 @@ namespace Switchboard {
             set_accels_for_action ("app.back", {"<Alt>Left", "Back"});
             set_accels_for_action ("app.quit", {"<Control>q"});
 
-            navigation_button = new Gtk.Button ();
+            navigation_button = new Gtk.Button.with_label (all_settings_label);
             navigation_button.action_name = "app.back";
             navigation_button.set_tooltip_markup (
                 Granite.markup_accel_tooltip (get_accels_for_action (navigation_button.action_name))
@@ -309,6 +309,12 @@ namespace Switchboard {
                 } else {
                     headerbar.title = current_plug.display_name;
 
+                    if (previous_plugs.size > 1) {
+                        navigation_button.label = previous_plugs.@get (0).display_name;
+                        previous_plugs.remove_at (previous_plugs.size - 1);
+                    } else {
+                        navigation_button.label = all_settings_label;
+                    }
                     navigation_button.show ();
 
                     search_box.sensitive = false;
@@ -353,8 +359,6 @@ namespace Switchboard {
                     previous_plugs.add (plug);
                 }
 
-                navigation_button.label = all_settings_label;
-
                 current_plug = plug;
 
                 // open window was set by command line argument
@@ -386,7 +390,7 @@ namespace Switchboard {
 
                 stack.set_visible_child_full ("main", Gtk.StackTransitionType.SLIDE_LEFT_RIGHT);
             } else {
-                if (previous_plugs.size > 0 && stack.get_visible_child_name () != "main") {
+                if (previous_plugs.size > 0) {
                     if (current_plug != null) {
                         current_plug.hidden ();
                     }
@@ -434,13 +438,6 @@ namespace Switchboard {
                 should_animate_next_transition = true;
             } else if (stack.transition_type == Gtk.StackTransitionType.NONE) {
                 stack.set_transition_type (Gtk.StackTransitionType.SLIDE_LEFT_RIGHT);
-            }
-
-            if (previous_plugs.size > 1 && stack.get_visible_child_name () != "main") {
-                navigation_button.label = previous_plugs.@get (0).display_name;
-                previous_plugs.remove_at (previous_plugs.size - 1);
-            } else {
-                navigation_button.label = all_settings_label;
             }
 
             plug.shown ();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -312,7 +312,7 @@ namespace Switchboard {
                     foreach (var plug in previous_plugs) {
                         if (stack.visible_child == plug.get_widget ()) {
                             current_plug = plug;
-                            continue;
+                            break;
                         }
                     }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -299,13 +299,9 @@ namespace Switchboard {
             });
 
             stack.notify["visible-child"].connect (() => {
-                foreach (var plug in previous_plugs) {
-                    if (stack.visible_child == plug.get_widget ()) {
-                        current_plug = plug;
-                    }
-                }
-
                 if (stack.visible_child == category_view) {
+                    current_plug = null;
+
                     headerbar.title = _("System Settings");
 
                     navigation_button.hide ();
@@ -313,6 +309,12 @@ namespace Switchboard {
                     search_box.sensitive = Switchboard.PlugsManager.get_default ().has_plugs ();
                     search_box.has_focus = search_box.sensitive;
                 } else {
+                    foreach (var plug in previous_plugs) {
+                        if (stack.visible_child == plug.get_widget ()) {
+                            current_plug = plug;
+                        }
+                    }
+
                     headerbar.title = current_plug.display_name;
 
                     if (previous_plugs.size > 1) {
@@ -338,16 +340,6 @@ namespace Switchboard {
             }
 
             Gtk.main ();
-        }
-
-        private string display_name_from_widget (Gtk.Widget widget) {
-            foreach (var plug in previous_plugs) {
-                if (widget == plug.get_widget ()) {
-                    return plug.display_name;
-                }
-            }
-
-            return _("System Settings");
         }
 
         public void load_plug (Switchboard.Plug plug) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -312,6 +312,7 @@ namespace Switchboard {
                     foreach (var plug in previous_plugs) {
                         if (stack.visible_child == plug.get_widget ()) {
                             current_plug = plug;
+                            continue;
                         }
                     }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -307,7 +307,11 @@ namespace Switchboard {
                     search_box.sensitive = Switchboard.PlugsManager.get_default ().has_plugs ();
                     search_box.has_focus = search_box.sensitive;
                 } else {
-                    headerbar.title = current_plug.display_name;
+                    foreach (var plug in previous_plugs) {
+                        if (stack.visible_child == plug.get_widget ()) {
+                            headerbar.title = plug.display_name;
+                        }
+                    }
 
                     if (previous_plugs.size > 1) {
                         navigation_button.label = previous_plugs.@get (0).display_name;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -299,6 +299,12 @@ namespace Switchboard {
             });
 
             stack.notify["visible-child"].connect (() => {
+                foreach (var plug in previous_plugs) {
+                    if (stack.visible_child == plug.get_widget ()) {
+                        current_plug = plug;
+                    }
+                }
+
                 if (stack.visible_child == category_view) {
                     headerbar.title = _("System Settings");
 
@@ -307,11 +313,7 @@ namespace Switchboard {
                     search_box.sensitive = Switchboard.PlugsManager.get_default ().has_plugs ();
                     search_box.has_focus = search_box.sensitive;
                 } else {
-                    foreach (var plug in previous_plugs) {
-                        if (stack.visible_child == plug.get_widget ()) {
-                            headerbar.title = plug.display_name;
-                        }
-                    }
+                    headerbar.title = current_plug.display_name;
 
                     if (previous_plugs.size > 1) {
                         navigation_button.label = previous_plugs.@get (0).display_name;
@@ -338,6 +340,16 @@ namespace Switchboard {
             Gtk.main ();
         }
 
+        private string display_name_from_widget (Gtk.Widget widget) {
+            foreach (var plug in previous_plugs) {
+                if (widget == plug.get_widget ()) {
+                    return plug.display_name;
+                }
+            }
+
+            return _("System Settings");
+        }
+
         public void load_plug (Switchboard.Plug plug) {
             Idle.add (() => {
                 if (!loaded_plugs.contains (plug.code_name)) {
@@ -362,8 +374,6 @@ namespace Switchboard {
                 if (previous_plugs.size == 0 || previous_plugs.@get (0) != plug) {
                     previous_plugs.add (plug);
                 }
-
-                current_plug = plug;
 
                 // open window was set by command line argument
                 if (open_window != null) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -298,6 +298,25 @@ namespace Switchboard {
                 }
             });
 
+            stack.notify["visible-child"].connect (() => {
+                if (stack.visible_child == category_view) {
+                    headerbar.title = _("System Settings");
+
+                    navigation_button.hide ();
+
+                    search_box.sensitive = Switchboard.PlugsManager.get_default ().has_plugs ();
+                    search_box.has_focus = search_box.sensitive;
+                } else {
+                    headerbar.title = current_plug.display_name;
+
+                    navigation_button.show ();
+
+                    search_box.sensitive = false;
+                }
+
+                search_box.text = "";
+            });
+
             if (Switchboard.PlugsManager.get_default ().has_plugs () == false) {
                 category_view.show_alert (_("No Settings Found"), _("Install some and re-launch Switchboard."), "dialog-warning");
                 search_box.sensitive = false;
@@ -334,13 +353,8 @@ namespace Switchboard {
                     previous_plugs.add (plug);
                 }
 
-                search_box.text = "";
-
-                // Launch plug's executable
                 navigation_button.label = all_settings_label;
-                navigation_button.show ();
 
-                headerbar.title = plug.display_name;
                 current_plug = plug;
 
                 // open window was set by command line argument
@@ -371,16 +385,6 @@ namespace Switchboard {
                 current_plug.hidden ();
 
                 stack.set_visible_child_full ("main", Gtk.StackTransitionType.SLIDE_LEFT_RIGHT);
-
-                headerbar.title = _("System Settings");
-
-                search_box.set_text ("");
-                search_box.sensitive = Switchboard.PlugsManager.get_default ().has_plugs ();
-                if (search_box.sensitive) {
-                    search_box.has_focus = true;
-                }
-
-                navigation_button.hide ();
             } else {
                 if (previous_plugs.size > 0 && stack.get_visible_child_name () != "main") {
                     if (current_plug != null) {
@@ -439,7 +443,6 @@ namespace Switchboard {
                 navigation_button.label = all_settings_label;
             }
 
-            search_box.sensitive = false;
             plug.shown ();
             stack.set_visible_child_name (plug.code_name);
         }


### PR DESCRIPTION
We can't rely on the nav button being the only way panes are switched, especially not in the future when we're using Hdy.Deck. Instead, we listen to the stack to see if the child has changed and update accordingly.

This also ensures that `current_plug` is accurate