### PR TITLE
Fix 'All Settings' no longer be shown as translated

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -28,7 +28,7 @@ namespace Switchboard {
     public class SwitchboardApp : Gtk.Application {
         public Gtk.SearchEntry search_box { get; private set; }
 
-        private string all_settings_label = _("All Settings");
+        private string all_settings_label = N_("All Settings");
         private uint configure_id;
 
         private Gee.ArrayList <Switchboard.Plug> previous_plugs;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -137,7 +137,7 @@ namespace Switchboard {
             set_accels_for_action ("app.back", {"<Alt>Left", "Back"});
             set_accels_for_action ("app.quit", {"<Control>q"});
 
-            navigation_button = new Gtk.Button.with_label (all_settings_label);
+            navigation_button = new Gtk.Button.with_label (_(all_settings_label));
             navigation_button.action_name = "app.back";
             navigation_button.set_tooltip_markup (
                 Granite.markup_accel_tooltip (get_accels_for_action (navigation_button.action_name))
@@ -327,7 +327,7 @@ namespace Switchboard {
                         navigation_button.label = previous_plugs.@get (0).display_name;
                         previous_plugs.remove_at (previous_plugs.size - 1);
                     } else {
-                        navigation_button.label = all_settings_label;
+                        navigation_button.label = _(all_settings_label);
                     }
                     navigation_button.show ();
 
@@ -394,7 +394,7 @@ namespace Switchboard {
 
         // Handles clicking the navigation button
         private void handle_navigation_button_clicked () {
-            if (navigation_button.label == all_settings_label) {
+            if (navigation_button.label == _(all_settings_label)) {
                 opened_directly = false;
 
                 previous_plugs.clear ();


### PR DESCRIPTION
Seems a regression from #168

## Before
![Screenshot from 2020-07-26 21-19-34](https://user-images.githubusercontent.com/26003928/88478768-e5218280-cf85-11ea-8424-a6c6ff09bc10.png)

## After
![Screenshot from 2020-07-26 21-17-17](https://user-images.githubusercontent.com/26003928/88478766-e2bf2880-cf85-11ea-8605-8afbfb03211d.png)
