### PR TITLE
Application: Remove handler for impossible case

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -413,12 +413,8 @@ namespace Switchboard {
                 deck.transition_duration = 200;
                 deck.visible_child = category_view;
             } else {
-                if (previous_plugs.size > 0) {
-                    load_plug (previous_plugs.@get (0));
-                    previous_plugs.remove_at (0);
-                } else {
-                    switch_to_plug (current_plug);
-                }
+                load_plug (previous_plugs.@get (0));
+                previous_plugs.remove_at (0);
             }
         }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -390,7 +390,15 @@ namespace Switchboard {
                     open_window = null;
                 }
 
-                switch_to_plug (plug);
+                if (opened_directly) {
+                    deck.transition_duration = 0;
+                    opened_directly = false;
+                } else if (deck.transition_duration == 0) {
+                    deck.transition_duration = 200;
+                }
+
+                deck.visible_child = plug.get_widget ();
+
                 return false;
             }, GLib.Priority.DEFAULT_IDLE);
         }
@@ -440,18 +448,6 @@ namespace Switchboard {
             }
 
             return false;
-        }
-
-        // Switches to the given plug
-        private void switch_to_plug (Switchboard.Plug plug) {
-            if (opened_directly) {
-                deck.transition_duration = 0;
-                opened_directly = false;
-            } else if (deck.transition_duration == 0) {
-                deck.transition_duration = 200;
-            }
-
-            deck.visible_child = plug.get_widget ();
         }
     }
 }


### PR DESCRIPTION
Because of these lines:
```
if (previous_plugs.size > 1) {
    navigation_button.label = previous_plugs.@get (0).display_name;
    previous_plugs.remove_at (previous_plugs.size - 1);
} else {
    navigation_button.label = _(all_settings_label);
}
```

It's impossible for the back button to be anything other than `all_settings_label`  and `previous_plugs` to be smaller than 1. So we don't need to handle a case that isn't possible to get into.

This is also nice because now it means `switch_plug` is only called by `load_plug` and we can combine these