### PR TITLE
Use icon-dropshadow CSS Class (+ small tweaks to accomodate this)

### DIFF
--- a/src/Widgets/CategoryIcon.vala
+++ b/src/Widgets/CategoryIcon.vala
@@ -27,6 +27,7 @@ public class Switchboard.CategoryIcon : Gtk.FlowBoxChild {
         width_request = 144;
 
         var icon = new Gtk.Image.from_icon_name (plug.icon, Gtk.IconSize.DND);
+        icon.get_style_context ().add_class ("icon-dropshadow");
         icon.tooltip_text = plug.description;
 
         var plug_name = new Gtk.Label (plug.display_name);
@@ -39,6 +40,7 @@ public class Switchboard.CategoryIcon : Gtk.FlowBoxChild {
         layout.halign = Gtk.Align.CENTER;
         layout.margin = 6;
         layout.orientation = Gtk.Orientation.VERTICAL;
+        layout.row_spacing = 6;
         layout.add (icon);
         layout.add (plug_name);
 


### PR DESCRIPTION
Uses the icon-dropshadow class from https://github.com/elementary/stylesheet/pull/928 so merge that first.

Looks like this in action:
![a](https://user-images.githubusercontent.com/4886639/104467245-df9c1100-5594-11eb-91ba-96a2cb3f2325.png)

P.S. Some icons have double shadows due to the baked-in manually added shadow.