### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,15 @@ add_project_arguments([
     language: 'c'
 )
 
+conf_data = configuration_data()
+conf_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+conf_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+conf_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: conf_data
+)
+
 plugs_dir = join_paths(get_option('prefix'), get_option('libdir'), 'switchboard')
 
 i18n = import('i18n')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -47,6 +47,11 @@ namespace Switchboard {
             application_id = "io.elementary.switchboard";
             flags |= ApplicationFlags.HANDLES_OPEN;
 
+            GLib.Intl.setlocale (LocaleCategory.ALL, "");
+            GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+            GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+            GLib.Intl.textdomain (GETTEXT_PACKAGE);
+
             if (GLib.AppInfo.get_default_for_uri_scheme ("settings") == null) {
                 var appinfo = new GLib.DesktopAppInfo (application_id + ".desktop");
                 try {

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ switchboard_deps = [
 
 executable(meson.project_name(),
     switchboard_files,
+    conf_file,
     dependencies: switchboard_deps,
     install: true
 )


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

We may probably open PRs for every switchboard plugins for similar reasons later, if this troubles the community, I sincerely apologize for this and great thanks for accepting specific downstream request.

Thanks in advance for reviewing this :-)