### PR TITLE
Application: force use portals

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -47,6 +47,7 @@ namespace Switchboard {
             application_id = "io.elementary.switchboard";
             flags |= ApplicationFlags.HANDLES_OPEN;
 
+            Environment.set_variable ("GTK_USE_PORTAL", "1", true);
             GLib.Intl.setlocale (LocaleCategory.ALL, "");
             GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
             GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");


### PR DESCRIPTION
This forces Switchboard to use portals even though it's not in a sandbox. What this means practically is that Switchboard plugs will use the native file chooser instead of the one from Gtk