### PR TITLE
SearchView: use clamp instead of width_chars

### DIFF
--- a/src/SearchView.vala
+++ b/src/SearchView.vala
@@ -26,7 +26,6 @@ public class Switchboard.SearchView : Gtk.Box {
             description = _("Try changing search terms."),
             icon = new ThemedIcon ("edit-find-symbolic")
         };
-        alert_view.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
 
         unowned SwitchboardApp app = (SwitchboardApp) GLib.Application.get_default ();
 
@@ -38,10 +37,16 @@ public class Switchboard.SearchView : Gtk.Box {
         listbox.set_filter_func (filter_func);
         listbox.set_placeholder (alert_view);
 
-        var scrolled = new Gtk.ScrolledWindow () {
-            child = listbox
+        var clamp = new Adw.Clamp () {
+            child = listbox,
+            maximum_size = 800
         };
 
+        var scrolled = new Gtk.ScrolledWindow () {
+            child = clamp
+        };
+
+        add_css_class (Granite.STYLE_CLASS_VIEW);
         append (scrolled);
 
         load_plugs.begin ();
@@ -137,15 +142,11 @@ public class Switchboard.SearchView : Gtk.Box {
                 pixel_size = 32
             };
 
-            var label = new Gtk.Label (description);
-            label.ellipsize = Pango.EllipsizeMode.MIDDLE;
-            label.max_width_chars = 80;
-            label.width_chars = 80;
-            label.xalign = 0;
-
-            var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
-                halign = Gtk.Align.CENTER
+            var label = new Gtk.Label (description) {
+                ellipsize = Pango.EllipsizeMode.MIDDLE
             };
+
+            var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
             box.append (image);
             box.append (label);
 


### PR DESCRIPTION
Instead of forcing a size with `width_chars` use `Adw.Clamp` to set a maximum size