### PR TITLE
Increase minimum height; remove unnecessary scrolled window

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -182,7 +182,7 @@ namespace Switchboard {
             main_window.icon_name = application_id;
             main_window.title = _("System Settings");
             main_window.add (grid);
-            main_window.set_size_request (640, 480);
+            main_window.set_size_request (640, 720);
 
             int window_x, window_y;
             var rect = Gtk.Allocation ();

--- a/src/CategoryView.vala
+++ b/src/CategoryView.vala
@@ -55,13 +55,8 @@ namespace Switchboard {
             category_grid.add (network_category);
             category_grid.add (system_category);
 
-            var category_scrolled = new Gtk.ScrolledWindow (null, null) {
-                hscrollbar_policy = Gtk.PolicyType.NEVER
-            };
-            category_scrolled.add (category_grid);
-
             add (alert_view);
-            add_named (category_scrolled, "category-grid");
+            add_named (category_grid, "category-grid");
         }
 
         public CategoryView (string? plug = null) {


### PR DESCRIPTION
This increases the minimum size of the Switchboard so that most plug windows do not require scrolling to access all the settings.

There seems little purpose in being able to resize the Switchboard to smaller than its natural size as it is only used occasionally.
Unfortunately, Switchboard does not know the natural sizes of all the plugs and its natural size is slightly too small for some plugs, so an explicit size request is used.

This change also addresses difficulty scrolling some plug windows e.g. https://github.com/elementary/switchboard-plug-pantheon-shell/pull/299.

