### PR TITLE
Do not quit until visible plug is ready

### DIFF
--- a/lib/Plug.vala
+++ b/lib/Plug.vala
@@ -73,6 +73,10 @@ public abstract class Switchboard.Plug : GLib.Object {
      * Inform if the plug should be shown or not
      */
     public bool can_show { get; set; default=true; }
+    /**
+     * Inform if the plug is ready to be destroyed
+     */
+    public bool can_close { get; set; default=true; }
 
     /**
      * Inform the application that the plug can now be listed in the available plugs.

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -403,11 +403,27 @@ namespace Switchboard {
         }
 
         private void shut_down () {
-            if (plug_widgets[deck.visible_child] != null && plug_widgets[deck.visible_child] is Switchboard.Plug) {
-                plug_widgets[deck.visible_child].hidden ();
+            // Hide main window to maintain responsiveness
+            main_window.hide ();
+
+            var visible_child = plug_widgets[deck.visible_child];
+            if (visible_child != null &&
+                visible_child is Switchboard.Plug) {
+
+                visible_child.hidden ();
+            } else {
+                Gtk.main_quit ();
             }
 
-            Gtk.main_quit ();
+            Timeout.add (100, () => {
+                if (visible_child.can_close) {
+                    Gtk.main_quit ();
+                    return Source.REMOVE;
+                } else {
+                    // Bluetooth plug requires time to shut down properly
+                    return Source.CONTINUE;
+                }
+            });
         }
 
         // Handles clicking the navigation button


### PR DESCRIPTION
Part of fixing https://github.com/elementary/switchboard-plug-bluetooth/issues/157

This PR adds a "can-close" plug property and checks the visible plug is ready before quitting.
