### PR TITLE
Plug: Remove unused category other

### DIFF
--- a/lib/Plug.vala
+++ b/lib/Plug.vala
@@ -24,7 +24,6 @@ public abstract class Switchboard.Plug : GLib.Object {
         HARDWARE = 1,
         NETWORK = 2,
         SYSTEM = 3,
-        OTHER = 4
     }
 
     /**

--- a/lib/Plug.vala
+++ b/lib/Plug.vala
@@ -23,7 +23,7 @@ public abstract class Switchboard.Plug : GLib.Object {
         PERSONAL = 0,
         HARDWARE = 1,
         NETWORK = 2,
-        SYSTEM = 3,
+        SYSTEM = 3
     }
 
     /**


### PR DESCRIPTION
Supersedes #250

We don't use this in our plugs at least (if so that plug won't be shown; originally #250 intended to fix this issue), so it's safe to remove this. See also https://github.com/elementary/switchboard/pull/250#issuecomment-1295904284