### PR TITLE
Fix terminal warning on navigate

### DIFF
--- a/lib/Plug.vala
+++ b/lib/Plug.vala
@@ -33,14 +33,14 @@ public abstract class Switchboard.Plug : GLib.Object {
 
     /**
      * The category under which the plug will be stored.
-     * 
+     *
      * Possible {@link Category} values are PERSONAL, HARDWARE, NETWORK or SYSTEM.
      */
     public Category category { get; construct; }
 
     /**
      * The unique name representing the plug.
-     * 
+     *
      * It is also used to recognise it with the open-plug command.
      * for example "system-pantheon-info" for the official Info plug of the pantheon desktop.
      */
@@ -95,16 +95,16 @@ public abstract class Switchboard.Plug : GLib.Object {
 
     /**
      * Called when the plug disappear to the user.
-     * 
+     *
      * This is not called when the plug got destroyed or the window is closed, use ~Plug () instead.
      */
     public abstract void hidden ();
 
     /**
      * This function should return the widget that contain the whole interface.
-     * 
+     *
      * When the user click on an action, the second parameter is send to the {@link search_callback} method
-     * 
+     *
      * @param search a {@link string} that represent the search.
      * @return a {@link Gee.TreeMap} containing two strings like {"Keyboard → Behavior → Duration", "keyboard<sep>behavior"}.
      */
@@ -112,7 +112,7 @@ public abstract class Switchboard.Plug : GLib.Object {
 
     /**
      * This function is used when the user click on a search result, it should show the selected setting (right tab…).
-     * 
+     *
      * @param location a {@link string} that represents the setting to show.
      */
     public abstract void search_callback (string location);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -288,7 +288,8 @@ namespace Switchboard {
                     previous_child.hidden ();
                 }
 
-                if (leaflet.visible_child == category_view) {
+                var visible_widget = leaflet.visible_child;
+                if (visible_widget is Switchboard.CategoryView) {
                     main_window.title = _("System Settings");
                     title_stack.visible_child = search_box;
 
@@ -296,9 +297,15 @@ namespace Switchboard {
 
                     search_box.sensitive = Switchboard.PlugsManager.get_default ().has_plugs ();
                 } else {
-                    plug_widgets[leaflet.visible_child].shown ();
-                    main_window.title = plug_widgets[leaflet.visible_child].display_name;
-                    title_stack.visible_child = title_label;
+                    var plug = plug_widgets[visible_widget];
+                    if (plug != null) {
+                        plug.shown ();
+                        main_window.title = plug.display_name;
+                        title_stack.visible_child = title_label;
+                    } else {
+                        critical ("Visible child is not CategoryView nor is associated with a Plug.");
+                    }
+
 
                     if (previous_child != null && previous_child is Switchboard.Plug) {
                         navigation_button.label = previous_child.display_name;


### PR DESCRIPTION
Fixes the terminal warnings noted here: https://github.com/elementary/switchboard/pull/246#pullrequestreview-1119421015

As we only create one categoryview it is better to check the visible child type.  Using `==` did not seem to be working and as the category view has no associated plug the `else` clause was giving errors.

At present we can assume all leaflet children except the single categoryview have an associated plug.  Should this change the code here will have to be revisited.

Review without whitespace changes which got fixed in passing.