### PR TITLE
Changes for Gtk4 port

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-switchboard (6.0.2) bionic; urgency=medium
+io.elementary.settings (6.0.2) jammy; urgency=medium
 
   * Release 6.0.2
   * Update translation files
@@ -8,7 +8,7 @@ switchboard (6.0.2) bionic; urgency=medium
 
  -- elementary, Inc. <builds@elementary.io>  Tue, 14 Jun 2022 17:48:32 +0000
 
-switchboard (6.0.1) bionic; urgency=medium
+io.elementary.settings (6.0.1) bionic; urgency=medium
 
   * Release 6.0.1 (#229)
   * Update translation files
@@ -19,7 +19,7 @@ switchboard (6.0.1) bionic; urgency=medium
 
  -- elementary, Inc. <builds@elementary.io>  Tue, 03 May 2022 19:47:51 +0000
 
-switchboard (6.0.0) bionic; urgency=medium
+io.elementary.settings (6.0.0) bionic; urgency=medium
 
   * Release 6.0.0 (#212)
   * Avoid setting search sensitivity (#207)
@@ -52,7 +52,7 @@ switchboard (6.0.0) bionic; urgency=medium
 
  -- elementary, Inc. <builds@elementary.io>  Wed, 14 Jul 2021 17:12:09 +0000
 
-switchboard (2.4.0) bionic; urgency=medium
+io.elementary.settings (2.4.0) bionic; urgency=medium
 
   * Release 2.4.0 (#155)
   * Respect an OS-wide dark preference (#99)
@@ -63,22 +63,22 @@ switchboard (2.4.0) bionic; urgency=medium
   * Update translation files
   * Update translation files
   * Update translation template
-  * Update io.elementary.switchboard.appdata.xml.in
+  * Update io.elementary.io.elementary.settings.appdata.xml.in
   * Add SearchView (#147)
   * Application: use move_focus when pressing down (#148)
 
  -- elementary, Inc. <builds@elementary.io>  Thu, 30 Apr 2020 20:49:00 +0000
 
-switchboard (2.3.9) bionic; urgency=medium
+io.elementary.settings (2.3.9) bionic; urgency=medium
 
   * Release 2.3.9 (#145)
   * Update translation files
   * Update translation template
-  * Update io.elementary.switchboard.appdata.xml.in
+  * Update io.elementary.io.elementary.settings.appdata.xml.in
 
  -- elementary, Inc. <builds@elementary.io>  Mon, 30 Mar 2020 21:02:44 +0000
 
-switchboard (2.3.8) bionic; urgency=medium
+io.elementary.settings (2.3.8) bionic; urgency=medium
 
   * Release 2.3.8 (#137)
   * Update translation files
@@ -93,7 +93,7 @@ switchboard (2.3.8) bionic; urgency=medium
 
  -- elementary, Inc. <builds@elementary.io>  Tue, 14 Jan 2020 23:18:47 +0000
 
-switchboard (2.3.7) bionic; urgency=medium
+io.elementary.settings (2.3.7) bionic; urgency=medium
 
   * Release 2.3.7 (#124)
   * Create release.yml
@@ -115,104 +115,104 @@ switchboard (2.3.7) bionic; urgency=medium
 
  -- elementary, Inc. <builds@elementary.io>  Mon, 04 Nov 2019 22:11:38 +0000
 
-switchboard (2.3.6) bionic; urgency=medium
+io.elementary.settings (2.3.6) bionic; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <codygarver@gmail.com>  Wed, 23 Jan 2019 02:18:24 -0600
 
-switchboard (2.3.5) bionic; urgency=medium
+io.elementary.settings (2.3.5) bionic; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Thu, 29 Nov 2018 09:44:15 -0600
 
-switchboard (2.3.4) bionic; urgency=medium
+io.elementary.settings (2.3.4) bionic; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Mon, 08 Oct 2018 11:03:13 -0500
 
-switchboard (2.3.3) bionic; urgency=medium
+io.elementary.settings (2.3.3) bionic; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Thu, 04 Oct 2018 06:54:04 -0500
 
-switchboard (2.3.2) bionic; urgency=medium
+io.elementary.settings (2.3.2) bionic; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Fri, 27 Jul 2018 02:38:23 -0500
 
-switchboard (2.3.1) bionic; urgency=medium
+io.elementary.settings (2.3.1) bionic; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Wed, 06 Jun 2018 04:27:04 -0500
 
-switchboard (2.3.0) xenial; urgency=medium
+io.elementary.settings (2.3.0) xenial; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Thu, 27 Jul 2017 20:46:40 -0500
 
-switchboard (2.2.1) xenial; urgency=medium
+io.elementary.settings (2.2.1) xenial; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Wed, 01 Feb 2017 11:31:08 -0600
 
-switchboard (2.2.0) xenial; urgency=medium
+io.elementary.settings (2.2.0) xenial; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Thu, 08 Dec 2016 11:42:46 -0600
 
-switchboard (2.1.0) xenial; urgency=medium
+io.elementary.settings (2.1.0) xenial; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Tue, 09 Aug 2016 15:49:10 -0500
 
-switchboard (2.0.2) trusty; urgency=medium
+io.elementary.settings (2.0.2) trusty; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Tue, 24 Nov 2015 22:48:36 -0600
 
-switchboard (2.0.1) trusty; urgency=low
+io.elementary.settings (2.0.1) trusty; urgency=low
 
   * Removed some configuration paths from the library
   * Fixed build with Valac 0.28
 
  -- Corentin "tintou" Noël <corentin@elementary.io>  Sun, 31 May 2015 11:45:22 +0100
 
-switchboard (2.0.0) trusty; urgency=low
+io.elementary.settings (2.0.0) trusty; urgency=low
 
   * Now using gmodule
 
  -- Corentin "tintou" Noël <corentin@elementary.io>  Sat, 09 Nov 2013 14:29:41 +0100
 
-switchboard (1.0.1) precise; urgency=low
+io.elementary.settings (1.0.1) precise; urgency=low
 
   * No more appmenu
 
  -- Cody Garver <cody@elementary.io>  Thu, 20 Jun 2013 04:22:32 -0500
 
-switchboard (1.0) precise; urgency=low
+io.elementary.settings (1.0) precise; urgency=low
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Sun, 09 Jun 2013 16:06:54 -0500
 
-switchboard (0.9) natty; urgency=low
+io.elementary.settings (0.9) natty; urgency=low
 
   * Now using libgranite, minor refactoring.
 
  -- Avi Romanoff <aviromanoff@gmail.com>  Mon, 22 Aug 2011 13:12:01 -0400
 
-switchboard (0.8) unstable; urgency=low
+io.elementary.settings (0.8) unstable; urgency=low
 
   * Initial Release.
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: switchboard
+Source: io.elementary.settings
 Section: admin
 Priority: optional
 Maintainer: elementary, Inc. <builds@elementary.io>
@@ -6,23 +6,22 @@ Build-Depends: debhelper (>= 10.5.1),
                gettext,
                libgee-0.8-dev (>= 0.5.3),
                libglib2.0-dev (>= 2.26.0),
-               libgranite-dev (>= 0.3.0~),
-               libgtk-3-dev (>= 3.10.0),
-               libhandy-1-dev (>= 0.8.0),
+               libgranite-7-dev,
+               libgtk-4-dev,
+               libadwaita-1-dev,
                meson,
                valac (>= 0.22)
 Standards-Version: 4.1.1
 Homepage: https://github.com/elementary/switchboard
 
-Package: switchboard
+Package: io.elementary.settings
 Architecture: any
-Depends: libswitchboard-2.0-0 (= ${binary:Version}),
+Depends: libswitchboard-3-0 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
-Provides: unity-control-center
 Pre-Depends: dpkg (>= 1.15.6)
 Description: Modular Settings Hub
- Switchboard is a modular system settings hub designed
+ Settings is a modular system settings hub designed
  for Pantheon desktop.
  .
  It features animated transitions, supports adding or
@@ -30,14 +29,14 @@ Description: Modular Settings Hub
  and follows the Human Interface Guidelines of
  elementary OS.
 
-Package: libswitchboard-2.0-dev
+Package: libswitchboard-3-dev
 Section: libdevel
 Architecture: any
-Depends: libswitchboard-2.0-0 (= ${binary:Version}), ${misc:Depends}
+Depends: libswitchboard-3-0 (= ${binary:Version}), ${misc:Depends}
 Description: Modular Settings Hub - development files
- Shared library to create plugs (settings panels) for Switchboard.
+ Shared library to create plugs (settings panels) for Settings.
  .
- Switchboard is a modular system settings hub designed
+ Settings is a modular system settings hub designed
  for Pantheon desktop.
  .
  It features animated transitions, supports adding or
@@ -46,16 +45,16 @@ Description: Modular Settings Hub - development files
  elementary OS.
  .
  This package contains the header and development files which are
- needed for building Switchboard plugs.
+ needed for building Settings plugs.
 
-Package: libswitchboard-2.0-0
+Package: libswitchboard-3-0
 Section: libs
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Modular Settings Hub - shared libraries
- Shared library to create plugs (settings panels) for Switchboard.
+ Shared library to create plugs (settings panels) for Settings.
  .
- Switchboard is a modular system settings hub designed
+ Settings is a modular system settings hub designed
  for Pantheon desktop.
  .
  It features animated transitions, supports adding or

--- a/debian/io.elementary.settings.install
+++ b/debian/io.elementary.settings.install
@@ -1,0 +1,6 @@
+usr/bin/io.elementary.settings
+usr/share/applications/io.elementary.settings.desktop
+usr/share/glib-2.0/schemas/io.elementary.settings.gschema.xml
+usr/share/icons
+usr/share/locale
+usr/share/metainfo/io.elementary.settings.appdata.xml

--- a/debian/libswitchboard-2.0-0.install
+++ b/debian/libswitchboard-2.0-0.install
@@ -1,1 +1,0 @@
-usr/lib/*/libswitchboard-2.0.so.*

--- a/debian/libswitchboard-2.0-dev.install
+++ b/debian/libswitchboard-2.0-dev.install
@@ -1,5 +1,0 @@
-usr/include/switchboard-2.0/*
-usr/lib/*/libswitchboard-2.0.so
-usr/lib/*/pkgconfig/switchboard-2.0.pc
-usr/share/vala/vapi/switchboard-2.0.deps
-usr/share/vala/vapi/switchboard-2.0.vapi

--- a/debian/libswitchboard-3-0.install
+++ b/debian/libswitchboard-3-0.install
@@ -1,0 +1,1 @@
+usr/lib/*/libswitchboard-3.so.*

--- a/debian/libswitchboard-3-0.symbols
+++ b/debian/libswitchboard-3-0.symbols
@@ -1,4 +1,4 @@
-libswitchboard-2.0.so.0 libswitchboard-2.0-0 #MINVER#
+libswitchboard-3.so.0 libswitchboard-3-0 #MINVER#
  switchboard_plug_category_get_type@Base 2.0~bzr468
  switchboard_plug_construct@Base 2.0~bzr468
  switchboard_plug_get_can_show@Base 2.0~bzr468

--- a/debian/libswitchboard-3-dev.install
+++ b/debian/libswitchboard-3-dev.install
@@ -1,0 +1,5 @@
+usr/include/switchboard-3/*
+usr/lib/*/libswitchboard-3.so
+usr/lib/*/pkgconfig/switchboard-3.pc
+usr/share/vala/vapi/switchboard-3.deps
+usr/share/vala/vapi/switchboard-3.vapi

--- a/debian/switchboard.install
+++ b/debian/switchboard.install
@@ -1,6 +1,0 @@
-usr/bin/io.elementary.switchboard
-usr/share/applications/io.elementary.switchboard.desktop
-usr/share/glib-2.0/schemas/io.elementary.switchboard.gschema.xml
-usr/share/icons
-usr/share/locale
-usr/share/metainfo/io.elementary.switchboard.appdata.xml


### PR DESCRIPTION
Switches over the main packaging branch to build the Gtk4 version of System Settings. This is needed to fix the gettext action in `main`

I've pushed a branch `deb-packaging-jammy` that's a snapshot of the latest release for the 6.0 series