### PR TITLE
Application: remove big window handle

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -184,13 +184,9 @@ namespace Switchboard {
 
             var window_eventcontrollerkey = new Gtk.EventControllerKey ();
 
-            var window_handle = new Gtk.WindowHandle () {
-                child = search_stack
-            };
-
             main_window = new Gtk.Window () {
                 application = this,
-                child = window_handle,
+                child = search_stack,
                 icon_name = application_id,
                 title = _("System Settings"),
                 titlebar = headerbar


### PR DESCRIPTION
This window handle is blocking the context menu for wallpapers in https://github.com/elementary/switchboard-plug-pantheon-shell/pull/377