### PR TITLE
SettingsPage: change css name

### DIFF
--- a/data/styles/SettingsPage.scss
+++ b/data/styles/SettingsPage.scss
@@ -1,4 +1,4 @@
-simplesettingspage {
+settingspage {
     > box > scrolledwindow {
         overshoot.top {
             background:

--- a/lib/SettingsPage.vala
+++ b/lib/SettingsPage.vala
@@ -88,7 +88,7 @@ public abstract class Switchboard.SettingsPage : Gtk.Widget {
     }
 
     class construct {
-        set_css_name ("simplesettingspage");
+        set_css_name ("settingspage");
     }
 
     construct {


### PR DESCRIPTION
Avoid conflicting with the stylesheet for Granite.SimpleSettingsPage