### PR TITLE
SettingsPage: make description settable

### DIFF
--- a/lib/SettingsPage.vala
+++ b/lib/SettingsPage.vala
@@ -102,21 +102,19 @@ public abstract class Switchboard.SettingsPage : Gtk.Widget {
         };
         title_label.add_css_class (Granite.STYLE_CLASS_H2_LABEL);
 
+        var description_label = new Gtk.Label (description) {
+            selectable = true,
+            use_markup = true,
+            wrap = true,
+            xalign = 0
+        };
+
         var header_area = new Gtk.Grid ();
         header_area.attach (title_label, 1, 0);
 
         if (description != null) {
-            var description_label = new Gtk.Label (description) {
-                selectable = true,
-                use_markup = true,
-                wrap = true,
-                xalign = 0
-            };
-
             header_area.attach (header_icon, 0, 0, 1, 2);
             header_area.attach (description_label, 1, 1, 2);
-
-            bind_property ("description", description_label, "label");
         } else {
             header_area.attach (header_icon, 0, 0);
         }
@@ -161,15 +159,15 @@ public abstract class Switchboard.SettingsPage : Gtk.Widget {
         grid.append (action_bar);
         grid.set_parent (this);
 
-        notify["icon"].connect (() => {
-            if (header_icon != null) {
-                header_icon.gicon = icon;
-            }
-        });
+        bind_property ("description", description_label, "label");
+        bind_property ("icon", header_icon, "gicon");
+        bind_property ("title", title_label, "label");
 
-        notify["title"].connect (() => {
-            if (title_label != null) {
-                title_label.label = title;
+        notify["description"].connect (() => {
+            if (description_label.parent == null) {
+                header_area.remove (header_icon);
+                header_area.attach (header_icon, 0, 0, 1, 2);
+                header_area.attach (description_label, 1, 1, 2);
             }
         });
     }


### PR DESCRIPTION
Sometimes we have dynamic descriptions so make sure can set descriptions outside of the constructor and we don't have to workaround by setting an empty string like:

https://github.com/elementary/switchboard-plug-bluetooth/pull/216/commits/b6a4ad411056c97163242c91d95ed6321d1f2a0f
