### PR TITLE
SettingsPage: add with_avatar option

### DIFF
--- a/data/styles/SettingsPage.scss
+++ b/data/styles/SettingsPage.scss
@@ -30,6 +30,19 @@ settingspage {
     }
 
     .header-area {
+        // avatar is inside of a widget
+        widget {
+            &:dir(ltr) {
+                margin-left: rem(4px);
+                margin-right: rem(9px);
+            }
+
+            &:dir(rtl) {
+                margin-left: rem(9px);
+                margin-right: rem(4px);
+            }
+        }
+
         image.large-icons {
             -gtk-icon-size: rem(48px);
 

--- a/lib/SettingsPage.vala
+++ b/lib/SettingsPage.vala
@@ -25,11 +25,6 @@ public abstract class Switchboard.SettingsPage : Gtk.Widget {
     public StatusType status_type { get; set; default = StatusType.NONE; }
 
     /**
-     * A widget to display in place of an icon in a Granite.SettingsSidebar
-     */
-    public Gtk.Widget? display_widget { get; construct; }
-
-    /**
      * A header to be sorted under in a Granite.SettingsSidebar
      */
     public string? header { get; construct; }
@@ -69,7 +64,17 @@ public abstract class Switchboard.SettingsPage : Gtk.Widget {
     /**
      * Creates a {@link Gtk.Switch} #status_switch in the header of #this
      */
-    public bool activatable { get; construct; }
+    public bool activatable { get; construct; default = false; }
+
+    /**
+     * Creates a {@link Adw.Avatar} to use instead of #icon
+     */
+    public bool with_avatar { get; construct; default = false; }
+
+    /**
+     * Custom image to use with avatar
+     */
+    public Gdk.Paintable avatar_paintable { get; set; }
 
     /**
      * Creates a {@link Gtk.Label} with a page description in the header of #this
@@ -90,10 +95,23 @@ public abstract class Switchboard.SettingsPage : Gtk.Widget {
     }
 
     construct {
-        var header_icon = new Gtk.Image.from_gicon (icon) {
-            icon_size = Gtk.IconSize.LARGE,
-            valign = Gtk.Align.START
-        };
+        Gtk.Widget header_widget;
+
+        if (!with_avatar) {
+            header_widget = new Gtk.Image.from_gicon (icon) {
+                icon_size = Gtk.IconSize.LARGE,
+                valign = Gtk.Align.START
+            };
+
+            bind_property ("icon", header_widget, "gicon");
+        } else {
+            header_widget = new Adw.Avatar (48, title, true) {
+                valign = START
+            };
+
+            bind_property ("avatar-paintable", header_widget, "custom-image", SYNC_CREATE);
+            bind_property ("title", header_widget, "text");
+        }
 
         var title_label = new Gtk.Label (title) {
             hexpand = true,
@@ -113,12 +131,12 @@ public abstract class Switchboard.SettingsPage : Gtk.Widget {
                 xalign = 0
             };
 
-            header_area.attach (header_icon, 0, 0, 1, 2);
+            header_area.attach (header_widget, 0, 0, 1, 2);
             header_area.attach (description_label, 1, 1, 2);
 
             bind_property ("description", description_label, "label");
         } else {
-            header_area.attach (header_icon, 0, 0);
+            header_area.attach (header_widget, 0, 0);
         }
 
         if (activatable) {
@@ -160,12 +178,6 @@ public abstract class Switchboard.SettingsPage : Gtk.Widget {
         grid.append (scrolled);
         grid.append (action_bar);
         grid.set_parent (this);
-
-        notify["icon"].connect (() => {
-            if (header_icon != null) {
-                header_icon.gicon = icon;
-            }
-        });
 
         notify["title"].connect (() => {
             if (title_label != null) {

--- a/lib/SettingsSidebarRow.vala
+++ b/lib/SettingsSidebarRow.vala
@@ -26,24 +26,11 @@ private class Switchboard.SettingsSidebarRow : Gtk.ListBoxRow {
         }
     }
 
-    public Gtk.Widget display_widget { get; construct; }
-
     public string? header { get; set; }
 
     public unowned SettingsPage page { get; construct; }
 
-    private Icon _icon;
-    public Icon icon {
-        get {
-            return _icon;
-        }
-        set {
-            _icon = value;
-            if (display_widget is Gtk.Image) {
-                ((Gtk.Image) display_widget).gicon = value;
-            }
-        }
-    }
+    public Icon icon { get; set; }
 
     public string status {
         set {
@@ -62,6 +49,7 @@ private class Switchboard.SettingsSidebarRow : Gtk.ListBoxRow {
         }
     }
 
+    private Gtk.Widget display_widget;
     private Gtk.Image status_icon;
     private Gtk.Label status_label;
     private Gtk.Label title_label;
@@ -95,13 +83,19 @@ private class Switchboard.SettingsSidebarRow : Gtk.ListBoxRow {
         };
         status_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
 
-        if (page.icon != null) {
+        if (!page.with_avatar) {
             display_widget = new Gtk.Image () {
                 icon_size = LARGE
             };
-            icon = page.icon;
+
+            page.bind_property ("icon", display_widget, "gicon", SYNC_CREATE);
         } else {
-            display_widget = page.display_widget;
+            display_widget = new Adw.Avatar (32, page.title, true) {
+                valign = START
+            };
+
+            page.bind_property ("avatar-paintable", display_widget, "custom-image", SYNC_CREATE);
+            page.bind_property ("title", display_widget, "text", SYNC_CREATE);
         }
 
         var overlay = new Gtk.Overlay ();


### PR DESCRIPTION
The only custom header widget we ever use is an Avatar, so add an option for that instead of the `display_widget` option which doesn't really work and isn't used

Can test with https://github.com/elementary/switchboard-plug-parental-controls/pull/187

![Screenshot from 2024-02-01 14 26 34](https://github.com/elementary/switchboard/assets/7277719/775b57f3-e126-43ab-a4b0-5f1d7f9c600f)


Theoretically SettingsSidebarRow is also set up in this branch, but it'll take more work to make a branch to test that with so I'm assuming I'll need to follow up there to make it work properly