### PR TITLE
Use Granite back button

### DIFF
--- a/lib/SettingsSidebar.vala
+++ b/lib/SettingsSidebar.vala
@@ -81,10 +81,15 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
             child = listbox
         };
 
+        var back_button = new Gtk.Button ();
+        back_button.add_css_class (Granite.STYLE_CLASS_BACK_BUTTON);
+
         var headerbar = new Adw.HeaderBar () {
             show_end_title_buttons = false,
-            show_title = false
+            show_title = false,
+            show_back_button = false
         };
+        headerbar.pack_start (back_button);
 
         var toolbarview = new Adw.ToolbarView () {
             content = scrolled,
@@ -115,6 +120,34 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
 
         stack.notify["visible-child-name"].connect (() => {
             visible_child_name = stack.visible_child_name;
+        });
+
+        back_button.clicked.connect (() => {
+            var navigation_view = (Adw.NavigationView) get_ancestor (typeof (Adw.NavigationView));
+
+            if (navigation_view != null) {
+                navigation_view.pop ();
+            }
+        });
+
+        map.connect (() => {
+            var navigation_view = (Adw.NavigationView) get_ancestor (typeof (Adw.NavigationView));
+
+            if (navigation_view == null) {
+                return;
+            }
+
+            var navigation_page = (Adw.NavigationPage) get_ancestor (typeof (Adw.NavigationPage));
+
+            if (navigation_page == null) {
+                return;
+            }
+
+            var previous_page = navigation_view.get_previous_page (navigation_page);
+
+            if (previous_page != null) {
+                back_button.label = previous_page.title;
+            }
         });
 
         bind_property ("show-title-buttons", toolbarview, "reveal-top-bars", SYNC_CREATE);


### PR DESCRIPTION
Something like this (Ignore that the back button is still broken for me):

![image](https://github.com/elementary/switchboard/assets/106322251/2347fc28-56a1-4125-9f17-e9a140d91544)
