### PR TITLE
SettingsSidebar: bind stack model to list

### DIFF
--- a/lib/SettingsSidebar.vala
+++ b/lib/SettingsSidebar.vala
@@ -101,9 +101,11 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
         listbox.set_header_func ((row, before) => {
             var header = ((SettingsSidebarRow) row).header;
             if (header != null) {
-                var before_header = ((SettingsSidebarRow) before).header;
-                if (header == before_header) {
-                    return;
+                if (before != null) {
+                    var before_header = ((SettingsSidebarRow) before).header;
+                    if (before_header != null && before_header == header) {
+                        return;
+                    }
                 }
 
                 var label = new Gtk.Label (header) {

--- a/lib/SettingsSidebar.vala
+++ b/lib/SettingsSidebar.vala
@@ -75,6 +75,7 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
             activate_on_single_click = true,
             selection_mode = Gtk.SelectionMode.SINGLE
         };
+        listbox.bind_model (stack.pages, create_widget_func);
 
         var scrolled = new Gtk.ScrolledWindow () {
             hscrollbar_policy = Gtk.PolicyType.NEVER,
@@ -92,9 +93,6 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
         };
         toolbarview.add_top_bar (headerbar);
         toolbarview.set_parent (this);
-
-        on_sidebar_changed ();
-        stack.pages.items_changed.connect (on_sidebar_changed);
 
         listbox.row_selected.connect ((row) => {
             stack.visible_child = ((SettingsSidebarRow) row).page;
@@ -124,22 +122,11 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
         get_first_child ().unparent ();
     }
 
-    private void on_sidebar_changed () {
-        weak Gtk.Widget listbox_child = listbox.get_first_child ();
-        while (listbox_child != null) {
-            weak Gtk.Widget next_child = listbox_child.get_next_sibling ();
-            listbox.remove (listbox_child);
-            listbox_child = next_child;
-        }
+    private Gtk.Widget create_widget_func (Object object) {
+        unowned var stack_page = (Gtk.StackPage) object;
+        unowned var page = (SettingsPage) stack_page.child;
+        var row = new SettingsSidebarRow (page);
 
-        weak Gtk.Widget child = stack.get_first_child ();
-        while (child != null) {
-            if (child is SettingsPage) {
-                var row = new SettingsSidebarRow ((SettingsPage) child);
-                listbox.append (row);
-            }
-
-            child = child.get_next_sibling ();
-        }
+        return row;
     }
 }

--- a/lib/SettingsSidebar.vala
+++ b/lib/SettingsSidebar.vala
@@ -101,6 +101,11 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
         listbox.set_header_func ((row, before) => {
             var header = ((SettingsSidebarRow) row).header;
             if (header != null) {
+                var before_header = ((SettingsSidebarRow) before).header;
+                if (header == before_header) {
+                    return;
+                }
+
                 var label = new Gtk.Label (header) {
                     halign = Gtk.Align.START,
                     xalign = 0


### PR DESCRIPTION
* Fixes updating the sidebar when stack items change
* And make sure we don't set duplicate headers

Can be tested with https://github.com/elementary/switchboard-plug-parental-controls/pull/191