### PR TITLE
CategoryView: use a Adw.ToolbarView

### DIFF
--- a/data/styles/CategoryView.scss
+++ b/data/styles/CategoryView.scss
@@ -1,38 +1,11 @@
-category-view {
-    box > scrolledwindow {
-        overshoot.top {
-            background:
-                linear-gradient(
-                    to top,
-                    #{'alpha(@accent_color, 0)'} 80%,
-                    #{'alpha(@accent_color, 0.25)'} 100%
-                ),
-                linear-gradient(
-                    #{'@borders'},
-                    rgba(black, 0.05) 1px,
-                    rgba(black, 0.0) rem(3px)
-                );
-        }
+category-view .main-clamp {
+    padding: rem(12px);
 
-        undershoot.top {
-            background:
-                linear-gradient(
-                    #{'@borders'},
-                    rgba(black, 0.05) 1px,
-                    rgba(black, 0.0) rem(3px)
-                );
-        }
+    .category-box {
+        border-spacing: rem(24px);
     }
 
-    scrolledwindow clamp {
-        padding: rem(12px);
-
-        box.vertical {
-            border-spacing: rem(24px);
-        }
-
-        .rich-list row {
-            border-radius: rem(3px);
-        }
+    .rich-list row {
+        border-radius: rem(3px);
     }
 }

--- a/data/styles/Plug.scss
+++ b/data/styles/Plug.scss
@@ -59,7 +59,7 @@ toolbarview {
 
     revealer.top-bar {
         &.raised {
-            background-color: #{'@insensitive_bg_color'};
+            background-color: rgba(black, 0.05);
             background-image:
                 linear-gradient(
                     to bottom,

--- a/data/styles/Plug.scss
+++ b/data/styles/Plug.scss
@@ -56,4 +56,46 @@ toolbarview {
         background: inherit;
         box-shadow: none;
     }
+
+    revealer.top-bar {
+        &.raised {
+            background-color: #{'@insensitive_bg_color'};
+            background-image:
+                linear-gradient(
+                    to bottom,
+                    #{'alpha(@highlight_color, 0.1)'},
+                    rgba(white, 0)
+                );
+            box-shadow:
+                inset 0 -1px 0 0 #{'alpha(@highlight_color, 0.2)'},
+                inset 0 1px 0 0 #{'alpha(@highlight_color, 0.3)'},
+                inset 1px 0 0 0 #{'alpha(@highlight_color, 0.07)'},
+                inset -1px 0 0 0 #{'alpha(@highlight_color, 0.07)'},
+                // Intentionally not in ems since it's used as a stroke
+                0 1px 0 0 #{'alpha(@borders, 0.4)'},
+                0 1px rem(2px) rgba(black, 0.2);
+
+            &:backdrop {
+                background-color: inherit;
+                background-image: none;
+                box-shadow:
+                    inset 0 -1px 0 0 #{'alpha(@highlight_color, 0.2)'},
+                    inset 0 1px 0 0 #{'alpha(@highlight_color, 0.3)'},
+                    inset 1px 0 0 0 #{'alpha(@highlight_color, 0.07)'},
+                    inset -1px 0 0 0 #{'alpha(@highlight_color, 0.07)'},
+                    0 0 0 1px #{'alpha(@borders, 0.3)'},
+                    0 1px rem(2px) rgba(black, 0.15);
+            }
+        }
+
+        &.raised.border {
+            box-shadow:
+                inset 0 -1px 0 0 #{'alpha(@highlight_color, 0.2)'},
+                inset 0 1px 0 0 #{'alpha(@highlight_color, 0.3)'},
+                inset 1px 0 0 0 #{'alpha(@highlight_color, 0.07)'},
+                inset -1px 0 0 0 #{'alpha(@highlight_color, 0.07)'},
+                // Intentionally not in ems since it's used as a stroke
+                0 1px 0 0 #{'alpha(@borders, 0.8)'};
+        }
+    }
 }

--- a/data/styles/Plug.scss
+++ b/data/styles/Plug.scss
@@ -59,13 +59,6 @@ toolbarview {
 
     revealer.top-bar {
         &.raised {
-            background-color: rgba(black, 0.05);
-            background-image:
-                linear-gradient(
-                    to bottom,
-                    #{'alpha(@highlight_color, 0.1)'},
-                    rgba(white, 0)
-                );
             box-shadow:
                 inset 0 -1px 0 0 #{'alpha(@highlight_color, 0.2)'},
                 inset 0 1px 0 0 #{'alpha(@highlight_color, 0.3)'},
@@ -76,8 +69,6 @@ toolbarview {
                 0 1px rem(2px) rgba(black, 0.2);
 
             &:backdrop {
-                background-color: inherit;
-                background-image: none;
                 box-shadow:
                     inset 0 -1px 0 0 #{'alpha(@highlight_color, 0.2)'},
                     inset 0 1px 0 0 #{'alpha(@highlight_color, 0.3)'},

--- a/src/CategoryView.vala
+++ b/src/CategoryView.vala
@@ -84,8 +84,7 @@ public class Switchboard.CategoryView : Adw.NavigationPage {
         };
 
         var toolbarview = new Adw.ToolbarView () {
-            content = scrolled,
-            top_bar_style = RAISED
+            content = scrolled
         };
         toolbarview.add_top_bar (headerbar);
 

--- a/src/CategoryView.vala
+++ b/src/CategoryView.vala
@@ -39,7 +39,6 @@ public class Switchboard.CategoryView : Adw.NavigationPage {
             show_title_buttons = true,
             title_widget = search_clamp
         };
-        headerbar.add_css_class (Granite.STYLE_CLASS_FLAT);
 
         var searchview = new SearchView (search_box);
 
@@ -77,17 +76,20 @@ public class Switchboard.CategoryView : Adw.NavigationPage {
             maximum_size = 800,
             tightening_threshold = 800
         };
+        clamp.add_css_class ("main-clamp");
 
         var scrolled = new Gtk.ScrolledWindow () {
             child = clamp,
             hscrollbar_policy = NEVER
         };
 
-        var box = new Gtk.Box (VERTICAL, 0);
-        box.append (headerbar);
-        box.append (scrolled);
+        var toolbarview = new Adw.ToolbarView () {
+            content = scrolled,
+            top_bar_style = RAISED
+        };
+        toolbarview.add_top_bar (headerbar);
 
-        child = box;
+        child = toolbarview;
         title = _("All Settings");
 
         load_default_plugs.begin ();


### PR DESCRIPTION
Saves us some view specific CSS and can be re-used in plugins where we have a stack switcher in the header

![Screenshot from 2024-03-21 14 42 43](https://github.com/elementary/switchboard/assets/7277719/4e73a785-c5ba-4dbb-b38e-1c8dcdc260f7)
