### PR TITLE
Plug.css: specifically target toolbars

### DIFF
--- a/data/styles/Plug.scss
+++ b/data/styles/Plug.scss
@@ -51,8 +51,8 @@ toolbarview {
         }
     }
 
-    headerbar,
-    actionbar {
+    revealer.top-bar headerbar,
+    revealer.bottom-bar actionbar {
         background: inherit;
         box-shadow: none;
     }


### PR DESCRIPTION
Fixes an issue where we're clearing styles for toolbars that aren't in the toolbarview areas we want to clear such as actionbars inside a frame in keyboard settings