### PR TITLE
Don't pop pages on escape

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -131,7 +131,9 @@ namespace Switchboard {
 
             category_view = new Switchboard.CategoryView (plug_to_open);
 
-            navigation_view = new Adw.NavigationView ();
+            navigation_view = new Adw.NavigationView () {
+                pop_on_escape = false
+            };
             navigation_view.add (category_view);
 
             main_window = new Gtk.Window () {


### PR DESCRIPTION
It currently blocks pressing escape to discard setting a new shortcut in the keyboard plug.