### PR TITLE
README: Add sassc to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You'll need the following dependencies:
 * libgtk-4-dev
 * libadwaita-1-dev (>= 1.4)
 * meson
+* sassc
 * valac
 
 Run `meson` to configure the build environment and then `ninja` to build


### PR DESCRIPTION
We now require sassc to build stylesheets.