### PR TITLE
SettingsSideBar: Fix selection of the correct row

### DIFF
--- a/lib/SettingsSidebar.vala
+++ b/lib/SettingsSidebar.vala
@@ -24,32 +24,24 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
     public bool show_title_buttons { get; set;}
 
     /**
-     * The name of the currently visible Granite.SettingsPage
+     * The name of the currently visible {@link SettingsPage}.
+     * Beware this is the name of the page as set via {@link Gtk.Stack.add_named}
+     * and not the title of the page.
      */
     public string? visible_child_name {
         get {
-            var selected_row = listbox.get_selected_row ();
-
-            if (selected_row == null) {
-                return null;
-            } else {
-                return ((SettingsSidebarRow) selected_row).page.title;
-            }
+            return stack.visible_child_name;
         }
         set {
-            weak Gtk.Widget listbox_child = listbox.get_first_child ();
-            while (listbox_child != null) {
-                if (!(listbox_child is SettingsSidebarRow)) {
-                    listbox_child = listbox_child.get_next_sibling ();
+            for (unowned var child = listbox.get_first_child (); child != null; child = child.get_next_sibling ()) {
+                if (!(child is SettingsSidebarRow)) {
                     continue;
                 }
 
-                if (((SettingsSidebarRow) listbox_child).page.title == value) {
-                    listbox.select_row ((Gtk.ListBoxRow) listbox_child);
+                if (((SettingsSidebarRow) child).page_name == value) {
+                    listbox.select_row ((Gtk.ListBoxRow) child);
                     break;
                 }
-
-                listbox_child = listbox_child.get_next_sibling ();
             }
         }
     }
@@ -134,7 +126,7 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
     private Gtk.Widget create_widget_func (Object object) {
         unowned var stack_page = (Gtk.StackPage) object;
         unowned var page = (SettingsPage) stack_page.child;
-        var row = new SettingsSidebarRow (page);
+        var row = new SettingsSidebarRow (stack_page.name, page);
 
         return row;
     }

--- a/lib/SettingsSidebarRow.vala
+++ b/lib/SettingsSidebarRow.vala
@@ -4,6 +4,8 @@
  */
 
 private class Switchboard.SettingsSidebarRow : Gtk.ListBoxRow {
+    public string page_name { get; construct; }
+
     public SettingsPage.StatusType status_type {
         set {
             switch (value) {
@@ -57,8 +59,9 @@ private class Switchboard.SettingsSidebarRow : Gtk.ListBoxRow {
     private Gtk.Label title_label;
     private string _title;
 
-    public SettingsSidebarRow (SettingsPage page) {
+    public SettingsSidebarRow (string page_name, SettingsPage page) {
         Object (
+            page_name: page_name,
             page: page
         );
     }


### PR DESCRIPTION
There was a mix up happening with settingspage title and the name of the visible child in the stack. This would cause e.g. when opening a plug for the first time via a search result the wrong result to show up. Also in further searches the wrong row would be selected. All of this is fixed now.