### PR TITLE
Application: don't set gtk_use_portal

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -35,7 +35,6 @@ namespace Switchboard {
             application_id = "io.elementary.settings";
             flags |= ApplicationFlags.HANDLES_OPEN;
 
-            Environment.set_variable ("GTK_USE_PORTAL", "1", true);
             GLib.Intl.setlocale (LocaleCategory.ALL, "");
             GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
             GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");


### PR DESCRIPTION
Now that we have Gtk.FileDialog which always uses the portal, we shouldn't set this any more