### PR TITLE
SettingsSideBar: Fix selection of the correct row

### DIFF
--- a/lib/SettingsSidebar.vala
+++ b/lib/SettingsSidebar.vala
@@ -120,15 +120,25 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
             }
         });
 
-        stack.notify["visible-child-name"].connect (() => {
-            visible_child_name = stack.visible_child_name;
-        });
+        stack.notify["visible-child"].connect (update_selection);
 
         bind_property ("show-title-buttons", toolbarview, "reveal-top-bars", SYNC_CREATE);
     }
 
     ~SettingsSidebar () {
         get_first_child ().unparent ();
+    }
+
+    private void update_selection () {
+        for (var child = listbox.get_first_child (); child != null; child = child.get_next_sibling ()) {
+            if (child is SettingsSidebarRow) {
+                var row = (SettingsSidebarRow) child;
+                if (row.page == stack.visible_child) {
+                    listbox.select_row ((Gtk.ListBoxRow) row);
+                    break;
+                }
+            }
+        }
     }
 
     private Gtk.Widget create_widget_func (Object object) {


### PR DESCRIPTION
Another version of  #336 that does things differently. It now doesn't break API nor will it require plugs to set a name for pages they add to the stack.

Still it fixes all the problems that would've been fixed by #336:
- If we click a search result without having opened the corresponding plug first the correct page will be preselected (e.g. when you search dock the dock page will be preselected instead of the first page as it is on main).
- The selected row in the sidebar now always matches the visible child