### PR TITLE
SettingsSidebar: Fix null access when selection of SettingsSidebarRow is cleared

### DIFF
--- a/lib/SettingsSidebar.vala
+++ b/lib/SettingsSidebar.vala
@@ -97,6 +97,10 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
         add_css_class (Granite.STYLE_CLASS_SIDEBAR);
 
         listbox.row_selected.connect ((row) => {
+            if (row == null) {
+                return;
+            }
+
             stack.visible_child = ((SettingsSidebarRow) row).page;
         });
 


### PR DESCRIPTION
Fixes #346
