### PR TITLE
Update Granite label styles

### DIFF
--- a/lib/SettingsSidebar.vala
+++ b/lib/SettingsSidebar.vala
@@ -114,12 +114,8 @@ public class Switchboard.SettingsSidebar : Gtk.Widget {
                     }
                 }
 
-                var label = new Gtk.Label (header) {
-                    halign = Gtk.Align.START,
-                    xalign = 0
-                };
+                var label = new Granite.HeaderLabel (header);
 
-                label.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
                 row.set_header (label);
             }
         });

--- a/lib/SettingsSidebarRow.vala
+++ b/lib/SettingsSidebarRow.vala
@@ -83,7 +83,7 @@ private class Switchboard.SettingsSidebarRow : Gtk.ListBoxRow {
             xalign = 0,
             visible = false
         };
-        status_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
+        status_label.add_css_class (Granite.CssClass.SMALL);
 
         if (!page.with_avatar) {
             display_widget = new Gtk.Image () {

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ gio_unix_dep = dependency('gio-unix-2.0')
 gmodule_dep = dependency('gmodule-2.0', version: '>=2.76')
 gtk_dep = dependency('gtk4', version: '>=3.10')
 gee_dep = dependency('gee-0.8')
-granite_dep = dependency('granite-7', version: '>=7.0.0')
+granite_dep = dependency('granite-7', version: '>=7.7.0')
 adwaita_dep = dependency('libadwaita-1', version: '>=1.4')
 m_dep = meson.get_compiler('c').find_library('m', required : false)
 

--- a/src/SearchView.vala
+++ b/src/SearchView.vala
@@ -190,8 +190,8 @@ public class Switchboard.SearchView : Gtk.Box {
                 use_markup = true
             };
             description_label.set_markup (GLib.Markup.escape_text (description, -1));
-            description_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
-            description_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
+            description_label.add_css_class (Granite.CssClass.DIM);
+            description_label.add_css_class (Granite.CssClass.SMALL);
 
             var grid = new Gtk.Grid () {
                 column_spacing = 12


### PR DESCRIPTION
There's a couple of other places where we have deprecation warnings, but I think these need more careful consideration since they have custom rules for wrapping and ellipsizing that aren't supported by granite yet